### PR TITLE
drivers: power: reset: Fix adb reboot bootloader/recovery

### DIFF
--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -306,6 +306,15 @@ static void msm_restart_prepare(const char *cmd)
 	if (force_warm_reboot)
 		pr_info("Forcing a warm reset of the system\n");
 
+	/* Force warm reset and allow device to
+	 * preserve memory on restart 
+	 * only for bootloader and recovery commands */
+	if (cmd != NULL) {
+		if ((!strncmp(cmd, "bootloader", 10)) ||
+				(!strncmp(cmd, "recovery", 8)))
+			need_warm_reset = true;
+	}
+
 	/* Hard reset the PMIC unless memory contents must be maintained. */
 	if (in_panic || force_warm_reboot || need_warm_reset)
 		qpnp_pon_system_pwr_off(PON_POWER_OFF_WARM_RESET);
@@ -365,8 +374,14 @@ static void msm_restart_prepare(const char *cmd)
 		} else if (!strncmp(cmd, "edl", 3)) {
 			enable_emergency_dload_mode();
 		} else {
+			pr_notice("%s : cmd is %s, set to reboot mode\n", __func__, cmd);
+			qpnp_pon_set_restart_reason(PON_RESTART_REASON_REBOOT);
 			__raw_writel(0x77665501, restart_reason);
 		}
+	} else {
+		pr_notice("%s : cmd is NULL, set to reboot mode\n", __func__);
+		qpnp_pon_set_restart_reason(PON_RESTART_REASON_REBOOT);
+		__raw_writel(0x776655AA, restart_reason);
 	}
 
 	flush_cache_all();

--- a/include/linux/input/qpnp-power-on.h
+++ b/include/linux/input/qpnp-power-on.h
@@ -61,6 +61,7 @@ enum pon_restart_reason {
 	PON_RESTART_REASON_KEYS_CLEAR		= 0x06,
 
 	/* 32 ~ 63 for OEMs/ODMs secific features */
+	PON_RESTART_REASON_REBOOT               = 0x10,
 	PON_RESTART_REASON_OEM_MIN		= 0x20,
 	PON_RESTART_REASON_OEM_MAX		= 0x3f,
 };


### PR DESCRIPTION
This change is based on OnePlus3 kernel which made a hack to force a soft reset as this preserves
memory contents, including pstore and other
persistent memory.

In this case we are focing the soft reset only if the bootloader or recovery is sent as cmd.

Reference: https://github.com/LineageOS/android_kernel_oneplus_msm8996/commit/f0979313e42697b3bc2311f0241cfb045c18eed0


Change-Id: Ibf201de9cdceab8434926d9e35e453c526c14056